### PR TITLE
Revert "bcm2835-mmc: Fix DMA usage"

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1354,14 +1354,14 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 		if (ret == 0) {
 			host->dma_cfg_rx = cfg;
 
-			host->have_dma = true;
+			host->use_dma = true;
 		} else {
 			pr_err("%s: unable to configure DMA channel. "
-			       "Falling back to PIO\n",
+			       "Faling back to PIO\n",
 			       mmc_hostname(mmc));
 			dma_release_channel(host->dma_chan_rxtx);
 			host->dma_chan_rxtx = NULL;
-			host->have_dma = false;
+			host->use_dma = false;
 		}
 	}
 #endif


### PR DESCRIPTION
This reverts commit f4258b9352afc1480dd1c29a11528e53b73bf356.